### PR TITLE
Use ip command instead of ifconfig when possible

### DIFF
--- a/swjsq.py
+++ b/swjsq.py
@@ -110,7 +110,15 @@ def get_mac(nic = '', to_splt = ':'):
         cmd = 'ipconfig /all'
         splt = '-'
     elif os.name == "posix":
-        cmd = 'ifconfig %s' % (nic or '-a')
+        if os.path.exists('/usr/bin/ip') or os.path.exists('/bin/ip'):
+            if nic:
+                cmd = 'ip link show dev %s' % nic
+            else:
+                # Unfortunately, loopback interface always comes first
+                # So we have to grep it out
+                cmd = 'ip link show up | grep -v loopback'
+        else:
+            cmd = 'ifconfig %s' % (nic or '-a')
         splt = ':'
     else:
         return FALLBACK_MAC


### PR DESCRIPTION
On Arch Linux, only `FALLBACK_MAC` can be obtained. And there's an error saying:

    sh: ifconfig: command not found

`ifconfig` is [deprecated](http://www.linuxfoundation.org/collaborate/workgroups/networking/iproute2) in favor of the new `ip` utility on Linux. Some distributions nowadays are even shipping `ip` only.

Tested on Arch Linux, Debian Jessie, and OS X El Capitan.