### PR TITLE
Fixes python version detection

### DIFF
--- a/swjsq.py
+++ b/swjsq.py
@@ -22,7 +22,7 @@ APP_VERSION = "2.0.3.4"
 PROTOCOL_VERSION = 108
 FALLBACK_MAC = '000000000000'
 
-PY3K = sys.version.startswith('3')
+PY3K = sys.version_info[0] == 3
 if not PY3K:
     import urllib2
     from cStringIO import StringIO as sio


### PR DESCRIPTION
According to [the official documentation](https://docs.python.org/2/library/sys.html), `sys.version` is a string used for display, and should not be parsed. To get version information, `sys.version_info` should be used instead.