### PR TITLE
resolve #73: fix errorno 717,718: 'account auth session failed result'

### DIFF
--- a/swjsq.py
+++ b/swjsq.py
@@ -384,6 +384,9 @@ def fast_d1ck(uname, pwd, login_type, save = True):
                 elif _['errno'] == 812:
                     print('Already upgraded, continuing')
                     i = 0
+                elif _['errno'] == 717 or _['errno'] == 718:# re-upgrade when get 'account auth session failed'
+                    i = 100
+                    continue
                 else:
                     time.sleep(300)#os._exit(4)
         except Exception as ex:


### PR DESCRIPTION
resolve #73
所使用的版本 (Python/Shell) ： python2.7
运行的系统环境及版本 openwrt 15.05.1
包含错误信息的日志：
Initializing upgrade
Error 717: account auth session failed result:402
Initializing upgrade
Error 718: account auth session failed result:403
产生错误的操作步骤：长时间运行后，reupgrade时报错，提速失效
运营商所在地：上海电信