### PR TITLE
Add `-u` parameter to python, fix docker log

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,4 @@ FROM python:2.7-alpine
 
 COPY swjsq.py /
 
-ENTRYPOINT ["python", "/swjsq.py"]
+ENTRYPOINT ["python", "-u", "/swjsq.py"]


### PR DESCRIPTION
When run with `docker run -d ...`, there will be almost nothing in `docker logs xunlei-fastdick`. And this patch could fix this.