### PR TITLE
Fix the problem with HTTP encoding

### DIFF
--- a/swjsq.py
+++ b/swjsq.py
@@ -63,13 +63,13 @@ OS_BUILD = "LRX22C"
 header_xl = {
     'Content-Type':'',
     'Connection': 'Keep-Alive',
-    'Accept-Encoding': 'gzip',
+    'Accept-Encoding': '',
     'User-Agent': 'android-async-http/xl-acc-sdk/version-2.1.1.177662'
 }
 header_api = {
     'Content-Type':'',
     'Connection': 'Keep-Alive',
-    'Accept-Encoding': 'gzip',
+    'Accept-Encoding': '',
     'User-Agent': 'Dalvik/2.1.0 (Linux; U; Android %s; %s Build/%s)' % (OS_VERSION, DEVICE_MODEL, OS_BUILD)
 }
 


### PR DESCRIPTION
I noticed that the codes set HTTP header 'Accept-Encoding' to 'gzip', but forgot to write code to decompress gzip HTTP packet, so it cause problem(see https://github.com/fffonion/Xunlei-Fastdick/issues/133).Fixing way is simple,change the 'gzip' to '', then the server will no loger reply you with gzip compressed packets.